### PR TITLE
Switching from LGTM to GHA/CodeQL

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+2022.11.7 -- Internal Release
+    Switching from LGTM code analysis to GitHub Actions using CodeQL, since LGTM is
+    shutting down!
+    
 2022.10.23 -- Properties added
     Added a single property, 'total energy#QuickMin#<forcefield>', to store the final
     energy in the database. Also added 'total energy' as a result for tables or

--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,8 @@ SEAMM QuickMin Plug-in
    :target: https://codecov.io/gh/molssi-seamm/quickmin_step
    :alt: Code Coverage
 
-.. image:: https://img.shields.io/lgtm/grade/python/g/molssi-seamm/quickmin_step.svg?logo=lgtm&logoWidth=18
-   :target: https://lgtm.com/projects/g/molssi-seamm/quickmin_step/context:python
+.. image:: https://github.com/molssi-seamm/quickmin_step/workflows/CodeQL/badge.svg
+   :target: https://github.com/molssi-seamm/quickmin_step/security/code-scanning
    :alt: Code Quality
 
 .. image:: https://github.com/molssi-seamm/quickmin_step/workflows/Documentation/badge.svg


### PR DESCRIPTION
Switching from LGTM code analysis to GitHub Actions using CodeQL, since LGTM is shutting down!