### PR TITLE
Bugfix: Corrected sign on gradients.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+2024.5.7 -- Bugfix: Corrected sign on gradients.
+    * OpenBabel calls "forces" "gradients", so needed to take the negative to get the
+      actual gradients.
+      
 2024.5.3 -- Added single point energy and Results.json
     * Added control to allow a single point energy as well as optimization. This
       supports using QuickMin with e.g energy scans.

--- a/quickmin_step/quickmin.py
+++ b/quickmin_step/quickmin.py
@@ -360,8 +360,8 @@ class QuickMin(seamm.Node):
                     energy = obFF.Energy(True)
                     units = obFF.GetUnit()
 
-                    # Capture the gradients
-                    factor = Q_(1.0, units).m_as("kJ/mol")
+                    # Capture the gradients. These appear to be forces, so negate
+                    factor = -Q_(1.0, units).m_as("kJ/mol")
                     for atom in openbabel.OBMolAtomIter(obmol):
                         # vector objects have to be de-referenced individually (sigh)
                         grad = obFF.GetGradient(atom)
@@ -402,8 +402,8 @@ class QuickMin(seamm.Node):
                 energy = obFF.Energy(True)
                 units = obFF.GetUnit()
 
-                # Capture the gradients
-                factor = Q_(1.0, units).m_as("kJ/mol")
+                # Capture the gradients. These appear to be forces, so negate
+                factor = -Q_(1.0, units).m_as("kJ/mol")
                 for atom in openbabel.OBMolAtomIter(obmol):
                     # vector objects have to be de-referenced individually (sigh)
                     grad = obFF.GetGradient(atom)


### PR DESCRIPTION
* OpenBabel calls "forces" "gradients", so needed to take the negative to get the actual gradients.